### PR TITLE
Set up a Rust-first repo structure

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -53,8 +53,8 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: coverage-data
-        path: ${{ github.workspace }}.coverage*
-        if-no-files-found: ignore
+        path: .coverage
+        if-no-files-found: warn
 
   coverage:
     name: Combine & check coverage.


### PR DESCRIPTION
PR still no more in draft. The main goal of this PR is to have:

- [x] a repo structure that we're all happy with
- [x] make sure the bindings & integration of the rust crate work
- [x] a way to build the python package, both for local dev and then a distribution build*

*the build process is not necessarily the most elegant one. We're between two choices matruin vs. setuptools-rust.
- matruin doesn't support SCM-based versioning, but is in general easier to use. `maturin build` "just works"
- setuptools-rust allows us to use SCM-based versioning but requires more custom scripts. Especially, it doesn't play well with dependencies [from parent directories](https://github.com/pypa/setuptools/issues/2339). The solution is to create a symlink & edit Cargo.toml --> then build

note: CI is currently not working with the new setup, I propose to create a new issue+PR where we address that separately.