### PR TITLE
Use coverage results from the installed package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         pip install .[test]
     - name: Run tests
       run: |
-        pytest --cov=python/outlines_core
+        pytest --cov=outlines_core
       env:
         COVERAGE_FILE: .coverage.${{ steps.matrix-id.outputs.id }}
     - name: Upload coverage data


### PR DESCRIPTION
This changes the coverage settings to use the coverage results from the installed source files and not the local project source files.