### PR TITLE
Relax Numpy Version Requirement in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
    "interegular",
-   "numpy<2.0.0",
+   "numpy",
    "cloudpickle",
    "diskcache",
    "pydantic>=2.0",


### PR DESCRIPTION
We're upgrading to `numpy>=2.0.0,<3.0` in Outlines, but there is a conflict with `outlines-core`'s numpy version.

This PR removes numpy version constraints.

Numpy is only used for type checking in `outlines-core`, specifically here: https://github.com/dottxt-ai/outlines-core/blob/main/python/outlines_core/models/tokenizer.py