### PR TITLE
Create `prelude` module to manage imports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,7 @@ pub mod regex;
 #[cfg(feature = "python-bindings")]
 mod python_bindings;
 
-mod primitives;
-pub use primitives::{State, Token, TokenId, TransitionKey};
+pub mod prelude;
 
-mod vocabulary;
-pub use vocabulary::Vocabulary;
-
-pub(crate) use std::{
-    collections::HashMap,
-    fmt::{self, Display},
-    ops::Deref,
-};
+pub mod primitives;
+pub mod vocabulary;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,10 @@
+pub use super::{
+    primitives::{State, Token, TokenId, TransitionKey},
+    vocabulary::Vocabulary,
+};
+
+pub(crate) use std::{
+    collections::{HashMap, HashSet},
+    fmt::{self, Display},
+    ops::Deref,
+};

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -1,9 +1,9 @@
 use crate::json_schema;
+use crate::prelude::*;
 use crate::regex::get_token_transition_keys;
 use crate::regex::get_vocabulary_transition_keys;
 use crate::regex::state_scan_tokens;
 use crate::regex::walk_fsm;
-use crate::*;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,5 +1,4 @@
-use crate::*;
-use std::collections::{HashMap, HashSet};
+use crate::prelude::*;
 
 pub fn walk_fsm(
     fsm_transitions: &HashMap<(State, TransitionKey), State>,

--- a/src/vocabulary.rs
+++ b/src/vocabulary.rs
@@ -1,11 +1,11 @@
-use crate::*;
+use crate::prelude::*;
 
 /// Vocabulary of an LLM.
 ///
 /// ## Examples
 ///
 /// ```rust
-/// # use outlines_core::*;
+/// # use outlines_core::prelude::*;
 /// #
 /// let vocabulary = Vocabulary::new()
 ///     .insert("blah", 0)
@@ -98,7 +98,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::*;
+    use crate::prelude::*;
 
     #[test]
     fn insert() {


### PR DESCRIPTION
`prelude` modules are pretty common in Rust. They are used to export important types of a crate from a single place.