### PR TITLE
Download the Rust compilers in manylinux

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -38,6 +38,9 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64 i686 aarch64
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y
+          CIBW_BEFORE_ALL_MACOS: curl -sSf https://sh.rustup.rs | sh -s -- -y
+          CIBW_BEFORE_ALL_WINDOWS: rustup target add i686-pc-windows-msvc
           CIBW_BEFORE_BUILD: pip install setuptools-rust
           CIBW_ENVIRONMENT: PATH="$HOME/.cargo/bin:$PATH"
           CIBW_TEST_COMMAND: python -c "import outlines_core; print(outlines_core.__version__)"


### PR DESCRIPTION
We currently do not install the rust compiler when building the wheels with `cibuildwheel`, which leads to [an error when trying to release on PyPi](https://github.com/dottxt-ai/outlines-core/actions/runs/11243191011/job/31258506079). This PR sets the `BEFORE...` environment variables, as specified [in the documentation](https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels).