### PR TITLE
Introduce `outlines_core.__version__` Attribute

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ignore_missing_imports = true
 [tool.coverage.run]
 omit = [
     "python/outlines_core/_version.py",
+    "python/outlines_core/__init__.py",
     "tests/*",
 ]
 branch = true

--- a/python/outlines_core/__init__.py
+++ b/python/outlines_core/__init__.py
@@ -1,4 +1,12 @@
 """Outlines is a Generative Model Programming Framework."""
+from importlib.metadata import PackageNotFoundError, version
+
 import outlines_core.models
+
+try:
+    __version__ = version("outlines_core")
+except PackageNotFoundError:
+    pass
+
 
 __all__ = ["models"]


### PR DESCRIPTION
`release_pypi.yml` [fails](https://github.com/dottxt-ai/outlines-core/actions/runs/11243729522/job/31260289324) with 

`Error: Command ['sh', '-c', 'python -c "import outlines_core; print(outlines_core.__version__)"'] failed with code 1. `

This PR directly uses `importlib.metadata` to resolve `__version__`