### PR TITLE
Skip musllinux 32-bit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ repository = "https://github.com/dottxt-ai/outlines-core"
 file="README.md"
 content-type = "text/markdown"
 
+[tool.cibuildwheel]
+skip = ["*-musllinux_i686"]
+
 [tool.setuptools]
 packages = ["outlines_core"]
 package-dir = {"" = "python"}


### PR DESCRIPTION
As stated in the [`cibuildwheel` documentation](https://cibuildwheel.pypa.io/en/stable/faq/#building-rust-wheels), Rust does not provide Cargo for musllinux 32-bit, so that needs to be skipped. By the way, maturin does handle this architecture.