### PR TITLE
Temporarily removing windows wheel building

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The build for wheels on Windows is [currently failing](https://github.com/dottxt-ai/outlines-core/actions/runs/11251163623/job/31281594559) because of `pyarrow`. This PR disables the build for Windows as we need to fix this issue quickly for Outlines and downstream libraries and open an issue.

```
ERROR: Could not build wheels for pyarrow, which is required to install pyproject.toml-based projects
```