### PR TITLE
Revert "Temporarily removing windows wheel building"

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Reverts dottxt-ai/outlines-core#47 as it doesn't look like Windows was the issue: https://github.com/dottxt-ai/outlines-core/actions/runs/11252963857/job/31287229544