### PR TITLE
Add installation prefix path for "Arrow" compilation

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -44,6 +44,8 @@ jobs:
           CIBW_BEFORE_BUILD: pip install setuptools-rust
           CIBW_ENVIRONMENT: PATH="$HOME/.cargo/bin:$PATH"
           CIBW_TEST_COMMAND: python -c "import outlines_core; print(outlines_core.__version__)"
+          CMAKE_PREFIX_PATH: ./dist
+
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Building the wheels for `pyarrow` is currently failing, [because](https://github.com/dottxt-ai/outlines-core/actions/runs/11252963857/job/31287229544) `CMAKE_PREFIX_PATH` is not set. I followed the [example build scripts](https://github.com/apache/arrow/blob/main/python/examples/minimal_build/build_venv.sh) provided by Arrow. We may also want to investigate why we need `pyarrow` to be installed in the first place.