### PR TITLE
Fix Wheel Build for `release_pypi.yaml`

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3
@@ -20,6 +20,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.12.3
@@ -31,10 +37,12 @@ jobs:
           toolchain: stable
           override: true
 
+      - run: rustup target add x86_64-apple-darwin
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_ARCHS_LINUX: x86_64 i686 aarch64
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_ARCHS_MACOS: x86_64 arm64


### PR DESCRIPTION
# Fixes
- [x] linux aarch64 builds successful
- [x] windows builds enabled and successful
- [x] macos builds successful

# Other changes
- add python3.13 builds

# Runs
- [macos](https://github.com/dottxt-ai/outlines-core/actions/runs/11268298509/job/31334809832?pr=57)
- [windows](https://github.com/dottxt-ai/outlines-core/actions/runs/11268298509/job/31334810170?pr=57)
- [ubuntu](https://github.com/dottxt-ai/outlines-core/actions/runs/11268298509/job/31334810015?pr=57)