### PR TITLE
Add missing backslash to `maxProperties < 1` case for JSON object types

### DIFF
--- a/src/json_schema/parsing.rs
+++ b/src/json_schema/parsing.rs
@@ -348,7 +348,7 @@ fn parse_string_type(obj: &serde_json::Map<String, Value>) -> Result<String> {
             .map_or("".to_string(), |n| format!("{}", n));
         let formatted_min = min_items
             .and_then(Value::as_u64)
-            .map_or("".to_string(), |n| format!("{}", n));
+            .map_or("0".to_string(), |n| format!("{}", n));
 
         Ok(format!(
             r#""{}{{{},{}}}""#,
@@ -416,14 +416,14 @@ fn parse_number_type(obj: &serde_json::Map<String, Value>) -> Result<String> {
         let fraction_quantifier = match (min_digits_fraction, max_digits_fraction) {
             (Some(min), Some(max)) => format!("{{{},{}}}", min, max),
             (Some(min), None) => format!("{{{},}}", min),
-            (None, Some(max)) => format!("{{,{}}}", max),
+            (None, Some(max)) => format!("{{0,{}}}", max),
             (None, None) => "+".to_string(),
         };
 
         let exponent_quantifier = match (min_digits_exponent, max_digits_exponent) {
             (Some(min), Some(max)) => format!("{{{},{}}}", min, max),
             (Some(min), None) => format!("{{{},}}", min),
-            (None, Some(max)) => format!("{{,{}}}", max),
+            (None, Some(max)) => format!("{{0,{}}}", max),
             (None, None) => "+".to_string(),
         };
 
@@ -448,7 +448,7 @@ fn parse_integer_type(obj: &serde_json::Map<String, Value>) -> Result<String> {
         let quantifier = match (min_digits, max_digits) {
             (Some(min), Some(max)) => format!("{{{},{}}}", min, max),
             (Some(min), None) => format!("{{{},}}", min),
-            (None, Some(max)) => format!("{{,{}}}", max),
+            (None, Some(max)) => format!("{{0,{}}}", max),
             (None, None) => "*".to_string(),
         };
 

--- a/tests/fsm/test_json_schema.py
+++ b/tests/fsm/test_json_schema.py
@@ -132,7 +132,7 @@ def test_match_number(pattern, does_match):
         # String with maximum length
         (
             {"title": "Foo", "type": "string", "maxLength": 3},
-            f'"{STRING_INNER}{{,3}}"',
+            f'"{STRING_INNER}{{0,3}}"',
             [('"ab"', True), ('"a""', False), ('"abcd"', False)],
         ),
         # String with minimum length
@@ -283,7 +283,7 @@ def test_match_number(pattern, does_match):
                 },
                 "required": ["count"],
             },
-            '\\{[ ]?"count"[ ]?:[ ]?(-)?(0|[1-9][0-9]{,2})[ ]?\\}',
+            '\\{[ ]?"count"[ ]?:[ ]?(-)?(0|[1-9][0-9]{0,2})[ ]?\\}',
             [('{ "count": 100 }', True), ('{ "count": 1000 }', False)],
         ),
         # integer with minimum and maximum digits


### PR DESCRIPTION
This PR adds a missing backslash to the `maxProperties < 1` case for JSON object types.  It also makes all repetition lower bounds explicit (i.e. use `{0,N}` instead of `{,N}`).