### PR TITLE
Remove `aarch64` from wheel build

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -43,7 +43,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp37-* cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*
-          CIBW_ARCHS_LINUX: x86_64 i686 aarch64
+          CIBW_ARCHS_LINUX: x86_64 i686
           CIBW_ARCHS_WINDOWS: AMD64 x86
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_BEFORE_ALL_LINUX: curl -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
The `aarch64` build is taking too long (more than an hour). Since we need to release the wheels as soon as possible we remove this build for now until we've figured out what is happening.