### PR TITLE
fix sdist archive set to v0.0.0

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -72,9 +72,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel setuptools-rust
+          pip install build setuptools-rust
       - name: Build sdist
-        run: python setup.py sdist
+        run: python -m build --sdist
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz


### PR DESCRIPTION
Related issue: https://github.com/pypa/setuptools-scm/issues/636

Attempt to ensure sdist archive isn't saved as v0.0.0

# Checking

These logs indicate `sdist` is now building a correct version. The release versions by tag, so the results may differ.

`main` sdist build logs indicating 0.0.0 used: <details>

```
2024-10-10T12:59:54.3122863Z running sdist
2024-10-10T12:59:54.3124102Z running egg_info
2024-10-10T12:59:54.3139055Z creating python/outlines_core.egg-info
2024-10-10T12:59:54.3241720Z writing python/outlines_core.egg-info/PKG-INFO
2024-10-10T12:59:54.3243732Z writing dependency_links to python/outlines_core.egg-info/dependency_links.txt
2024-10-10T12:59:54.3247510Z writing requirements to python/outlines_core.egg-info/requires.txt
2024-10-10T12:59:54.3249074Z writing top-level names to python/outlines_core.egg-info/top_level.txt
2024-10-10T12:59:54.3251157Z writing manifest file 'python/outlines_core.egg-info/SOURCES.txt'
2024-10-10T12:59:54.3289533Z reading manifest file 'python/outlines_core.egg-info/SOURCES.txt'
2024-10-10T12:59:54.3291118Z adding license file 'LICENSE'
2024-10-10T12:59:54.3297893Z writing manifest file 'python/outlines_core.egg-info/SOURCES.txt'
2024-10-10T12:59:54.3299381Z running check
2024-10-10T12:59:54.3325261Z creating outlines_core-0.0.0
2024-10-10T12:59:54.3326991Z creating outlines_core-0.0.0/python
2024-10-10T12:59:54.3328231Z creating outlines_core-0.0.0/python/outlines_core
2024-10-10T12:59:54.3329599Z creating outlines_core-0.0.0/python/outlines_core.egg-info
```

</details>

This PRs smoke test:

<details>

```
2024-10-10T17:51:57.9969388Z running sdist
2024-10-10T17:51:57.9971304Z running egg_info
2024-10-10T17:51:58.0006612Z writing python/outlines_core.egg-info/PKG-INFO
2024-10-10T17:51:58.0029902Z writing dependency_links to python/outlines_core.egg-info/dependency_links.txt
2024-10-10T17:51:58.0042792Z writing requirements to python/outlines_core.egg-info/requires.txt
2024-10-10T17:51:58.0044894Z writing top-level names to python/outlines_core.egg-info/top_level.txt
2024-10-10T17:51:58.0309164Z adding license file 'LICENSE'
2024-10-10T17:51:58.0322919Z writing manifest file 'python/outlines_core.egg-info/SOURCES.txt'
2024-10-10T17:51:58.0324684Z running check
2024-10-10T17:51:58.0355472Z creating outlines_core-0.1.dev1+gd990d66
```

</details>