### PR TITLE
Support MacOS 13 and MacOS 14 builds

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-13, macos-14, windows-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We are currently only supporting `macos-latest` which [seems to be macOS 15](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners). At the very least, LM Studio reported that the wheels were not available for MacOS 14. This PR fixes this.