### PR TITLE
Generate rust coverage data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,20 +11,20 @@ jobs:
     name: Check the code style
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - uses: pre-commit/action@v3.0.0
 
   tests:
-    name: Run the tests
+    name: Run python tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -58,12 +58,12 @@ jobs:
         overwrite: true
 
   coverage:
-    name: Combine & diff check coverage.
+    name: Check combined coverage
     needs: [tests, cargo-test]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -114,7 +114,7 @@ jobs:
     name: Build Wheel and Test SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build SDist and Wheel
         run: ./.github/scripts/build_sdist_and_wheel.sh
 
@@ -122,31 +122,30 @@ jobs:
     name: Run Cargo tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    # toolchain choice needs to happen before cache: rustc version used as its cache key
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
 
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
+    - name: Install cargo tarpaulin if not cached
+      run: |
+        if ! command -v cargo-tarpaulin &> /dev/null; then
+          echo "cargo-tarpaulin is not found, installing..."
+          cargo install cargo-tarpaulin
+        else
+          echo "cargo-tarpaulin is cached"
+        fi
 
-    - name: Cache Cargo dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Run cargo test
-      run: cargo test
-      
-    - name: Install cargo tarpaulin
-      run: cargo install cargo-tarpaulin
-      
     - name: Generate rust code coverage
-      run: cargo tarpaulin --out=Lcov --output-dir=rust-coverage --engine=llvm --no-dead-code --workspace --verbose
+      run: >
+        cargo tarpaulin
+        --out=Lcov
+        --output-dir=rust-coverage
+        --engine=llvm
+        --exclude-files=src/python_bindings/*
+        --no-dead-code
+        --workspace
+        --verbose
       env:
         RUSTFLAGS: -C instrument-coverage
 
@@ -163,21 +162,19 @@ jobs:
     name: Run Cargo audit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Cache Cargo dependencies
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Install cargo-audit
-      run: cargo install cargo-audit
+    - uses: actions/checkout@v4
+    # toolchain choice needs to happen before cache: rustc version used as its cache key
+    - uses: dtolnay/rust-toolchain@stable
+    - uses: Swatinem/rust-cache@v2
+
+    - name: Install cargo audit if not cached
+      run: |
+        if ! command -v cargo-audit &> /dev/null; then
+          echo "cargo-audit is not found, installing..."
+          cargo install cargo-audit
+        else
+          echo "cargo-audit is cached"
+        fi
+
     - name: Run cargo audit
       run: cargo audit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,8 +58,8 @@ jobs:
         overwrite: true
 
   coverage:
-    name: Combine & check coverage.
-    needs: tests
+    name: Combine & diff check coverage.
+    needs: [tests, cargo-test]
     runs-on: ubuntu-latest
 
     steps:
@@ -76,9 +76,18 @@ jobs:
         run: |
           pip install --upgrade "coverage[toml]>=5.1" diff-cover
 
-      - uses: actions/download-artifact@v4
+      - name: Install lcov
+        run: sudo apt-get update && sudo apt-get install -yqq lcov
+
+      - name: Download python coverage data
+        uses: actions/download-artifact@v4
         with:
           name: coverage-data
+
+      - name: Download rust coverage data
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-coverage-data
 
       - name: Fetch main for coverage diff
         run: |
@@ -87,9 +96,10 @@ jobs:
       - name: Combine coverage & fail if it's <100%.
         run: |
           python -m coverage combine
-          python -m coverage html --skip-covered --skip-empty
-          python -m coverage xml
-          diff-cover coverage.xml --markdown-report=coverage.md --fail-under=100 || (cat coverage.md >> $GITHUB_STEP_SUMMARY && exit 1)
+          python -m coverage lcov
+          lcov -a coverage.lcov -a lcov.info -o combined_coverage
+          genhtml combined_coverage --output-directory htmlcov
+          diff-cover combined_coverage --markdown-report=coverage.md --fail-under=100 || (cat coverage.md >> $GITHUB_STEP_SUMMARY && exit 1)
 
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v4
@@ -113,11 +123,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
         override: true
+
     - name: Cache Cargo dependencies
       uses: actions/cache@v2
       with:
@@ -126,8 +138,26 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Run cargo test
       run: cargo test
+      
+    - name: Install cargo tarpaulin
+      run: cargo install cargo-tarpaulin
+      
+    - name: Generate rust code coverage
+      run: cargo tarpaulin --out=Lcov --output-dir=rust-coverage --engine=llvm --no-dead-code --workspace --verbose
+      env:
+        RUSTFLAGS: -C instrument-coverage
+
+    - name: Upload rust coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: rust-coverage-data
+        path: rust-coverage/
+        if-no-files-found: ignore
+        include-hidden-files: true
+        overwrite: true
 
   cargo-audit:
     name: Run Cargo audit


### PR DESCRIPTION
Closes #33 

In order to retain our python `coverage` and `diff-cover` tool chain we're:
- generating code coverage file in `lcov` format with `cargo-tarpaulin`
- creating python coverage file in `lcov` instead of `xml`
- combining these coverage artifacts with `lcov` into one
- `diff-cover` seems to be able to handle combined `lcov` file

`genhtml` tool is used instead of `coverage html` to create html from combined file, which will create a bit different UI, but nothing major seems to change.

From something like this:
![python code coverage report](https://github.com/user-attachments/assets/9b5cbde1-d707-4793-a86a-758c876c6ae6)

To this:
![lcov code coverage report](https://github.com/user-attachments/assets/d3cc10c8-e70a-43b0-b490-17abc1358ff1)

Also changed in PR:
- `actions-rs` action is archived, `dtolnay/rust-toolchain` now used
- improved caching:
    - for binaries
    - and in general `Swatinem/rust-cache` currently is the best way to handle rust cache workflows, it's a "smart caching for rust/cargo projects with sensible defaults"