### PR TITLE
fix: Handle Salamandra and OpenCoder tokenizers

### DIFF
--- a/python/outlines_core/fsm/regex.py
+++ b/python/outlines_core/fsm/regex.py
@@ -342,9 +342,11 @@ def make_deterministic_fsm(fsm: FSM) -> Tuple[BetterFSM, Dict[int, int]]:
 
 re_llama_byte_token = re.compile(r"^<0x[0-9A-F]{2}>$")
 
-# The "▁*" prefix is required to handle Gemma and GPT-SW3 tokenizers, and the "\.*"
-# suffix is required to handle the NorwAI tokenizer.
-re_replacement_seq = re.compile(r"^▁*�+\.*$")
+# The "▁*" prefix is required to handle Gemma and GPT-SW3 tokenizers.
+# The "\.*" suffix is required to handle the NorwAI tokenizer.
+# The "\.*" prefix is required to handle the Salamandra tokenizer.
+# The "s*$" suffix is required to handle the OpenCoder tokenizer.
+re_replacement_seq = re.compile(r"^▁*\.*�+\.*s*$")
 
 
 # Copied from transformers.models.gpt2.tokenization_gpt2.bytes_to_unicode


### PR DESCRIPTION
Salamandra and OpenCoder tokenizers use ".�" and "�s" in their vocabularies, respectively, which causes errors with Outlines. 

This is similar to [this previous PR](https://github.com/dottxt-ai/outlines/pull/763), which featured other variations of the � symbol, and was fixed then by extending the `re_replacement_seq` regex to accommodate these variations. This PR does exactly the same as before, adding the options of having a "." before �, as well as an "s" after.