### PR TITLE
Fix handling of the anything_else check

### DIFF
--- a/python/outlines_core/fsm/regex.py
+++ b/python/outlines_core/fsm/regex.py
@@ -87,7 +87,7 @@ class BetterFSM(FSM):
                 {
                     k: v
                     for k, v in self.alphabet._symbol_mapping.items()
-                    if k != anything_else
+                    if not isinstance(k, _AnythingElseCls)
                 },
             )
 


### PR DESCRIPTION
Should not be checking for instance equality this breaks multiprocessing. Better to just check the type.