### PR TITLE
Use a script to automatically set the version in `Cargo.toml`

### DIFF
--- a/.github/scripts/cargo_version_bumper.py
+++ b/.github/scripts/cargo_version_bumper.py
@@ -1,0 +1,40 @@
+# From https://github.com/Intreecom/scyllapy/blob/05fdab32dd7468c26533de5fdfe9627fa3e38445/scripts/version_bumper.py
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--target",
+        "-t",
+        dest="target",
+        type=Path,
+        default="Cargo.toml",
+    )
+    parser.add_argument("version", type=str)
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main function."""
+    args = parse_args()
+    with args.target.open("r") as f:
+        contents = f.read()
+
+    contents = re.sub(
+        r"version\s*=\s*\"(.*)\"",
+        f'version = "{args.version}"',
+        contents,
+        count=1,
+    )
+
+    with args.target.open("w") as f:
+        f.write(contents)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -21,6 +21,10 @@ jobs:
         with:
           python-version: '3.10'
 
+      - name: Bump Cargo version
+        run: |
+          python ./.github/scripts/cargo_version_bumper.py --target Cargo.toml "${{ github.ref_name }}"
+
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3
@@ -68,7 +72,6 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: MACOSX_DEPLOYMENT_TARGET=10.12
           CIBW_TEST_COMMAND: python -c "import outlines_core; print(outlines_core.__version__)"
           CMAKE_PREFIX_PATH: ./dist
-
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release_rust.yaml
+++ b/.github/workflows/release_rust.yaml
@@ -13,6 +13,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Bump Cargo version
+      run: |
+        python ./.github/scripts/cargo_version_bumper.py --target Cargo.toml "${{ github.ref_name }}"
+
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outlines-core"
-version = "0.1.21"
+version = "0.0.0"
 edition = "2021"
 description = "Structured Generation"
 license = "Apache-2.0"


### PR DESCRIPTION
Closes #106. Failures are expected, but show that the script is working. I'll remove the `Make release workflows run in CI` commit before merging`, and will cut a new release afterwards to make sure this works.