### PR TITLE
Switch from HashMap -> FxHashMap for better compilation performance. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bincode = "2.0.0-rc.3"
 # Fragile dependencies, minor updates often break the code
 hf-hub = "=0.3.2"
 tokenizers = { version = "=0.20.3", features = ["http"] }
+rustc-hash = "2.1.0"
 
 [features]
 python-bindings = ["pyo3"]

--- a/src/index.rs
+++ b/src/index.rs
@@ -4,24 +4,24 @@ use crate::regex::{get_vocabulary_transition_keys, state_scan_tokens};
 use crate::vocabulary::Vocabulary;
 use crate::{Error, Result};
 use bincode::{Decode, Encode};
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 #[derive(Debug)]
 pub struct FSMInfo {
     pub(crate) initial: State,
-    pub(crate) finals: HashSet<State>,
-    pub(crate) transitions: HashMap<(State, TransitionKey), State>,
+    pub(crate) finals: FxHashSet<State>,
+    pub(crate) transitions: FxHashMap<(State, TransitionKey), State>,
     pub(crate) alphabet_anything_value: TransitionKey,
-    pub(crate) alphabet_symbol_mapping: HashMap<String, TransitionKey>,
+    pub(crate) alphabet_symbol_mapping: FxHashMap<String, TransitionKey>,
 }
 
 impl FSMInfo {
     pub fn new(
         initial: State,
-        finals: HashSet<State>,
-        transitions: HashMap<(State, TransitionKey), State>,
+        finals: FxHashSet<State>,
+        transitions: FxHashMap<(State, TransitionKey), State>,
         alphabet_anything_value: TransitionKey,
-        alphabet_symbol_mapping: HashMap<String, TransitionKey>,
+        alphabet_symbol_mapping: FxHashMap<String, TransitionKey>,
     ) -> Self {
         Self {
             initial,
@@ -36,8 +36,8 @@ impl FSMInfo {
 #[derive(Debug, Encode, Decode)]
 pub struct Index {
     initial: u32,
-    finals: HashSet<u32>,
-    states_to_token_subsets: HashMap<u32, HashMap<u32, u32>>,
+    finals: FxHashSet<u32>,
+    states_to_token_subsets: FxHashMap<u32, FxHashMap<u32, u32>>,
     eos_token_id: u32,
 }
 
@@ -46,11 +46,11 @@ impl Index {
         fsm_info: &FSMInfo,
         vocabulary: &Vocabulary,
         eos_token_id: u32,
-        frozen_tokens: HashSet<String>,
+        frozen_tokens: FxHashSet<String>,
     ) -> Result<Self> {
-        let mut states_to_token_subsets: HashMap<u32, HashMap<u32, u32>> = HashMap::new();
-        let mut seen: HashSet<State> = HashSet::new();
-        let mut next_states: HashSet<State> = HashSet::from([fsm_info.initial]);
+        let mut states_to_token_subsets: FxHashMap<u32, FxHashMap<u32, u32>> = FxHashMap::default();
+        let mut seen: FxHashSet<State> = FxHashSet::default();
+        let mut next_states: FxHashSet<State> = FxHashSet::from_iter([fsm_info.initial]);
 
         let vocabulary_transition_keys = get_vocabulary_transition_keys(
             &fsm_info.alphabet_symbol_mapping,
@@ -126,7 +126,7 @@ impl Index {
         self.finals.contains(&state)
     }
 
-    pub(crate) fn transitions(&self) -> &HashMap<u32, HashMap<u32, u32>> {
+    pub(crate) fn transitions(&self) -> &FxHashMap<u32, FxHashMap<u32, u32>> {
         &self.states_to_token_subsets
     }
 }

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 
 pub fn walk_fsm(
-    fsm_transitions: &HashMap<(State, TransitionKey), State>,
+    fsm_transitions: &FxHashMap<(State, TransitionKey), State>,
     _fsm_initial: State,
-    fsm_finals: &HashSet<State>,
+    fsm_finals: &FxHashSet<State>,
     token_transition_keys: &[TransitionKey],
     start_state: State,
     full_match: bool,
@@ -39,14 +39,14 @@ pub fn walk_fsm(
 }
 
 pub fn state_scan_tokens(
-    fsm_transitions: &HashMap<(State, TransitionKey), State>,
+    fsm_transitions: &FxHashMap<(State, TransitionKey), State>,
     fsm_initial: State,
-    fsm_finals: &HashSet<State>,
+    fsm_finals: &FxHashSet<State>,
     vocabulary: &Vocabulary,
-    vocabulary_transition_keys: &HashMap<Token, Vec<TransitionKey>>,
+    vocabulary_transition_keys: &FxHashMap<Token, Vec<TransitionKey>>,
     start_state: State,
-) -> HashSet<(TokenId, State)> {
-    let mut res = HashSet::new();
+) -> FxHashSet<(TokenId, State)> {
+    let mut res = FxHashSet::default();
 
     for (token, token_ids) in vocabulary.iter() {
         let token_transition_keys = &vocabulary_transition_keys[token];
@@ -72,7 +72,7 @@ pub fn state_scan_tokens(
 }
 
 pub fn get_token_transition_keys(
-    alphabet_symbol_mapping: &HashMap<String, TransitionKey>,
+    alphabet_symbol_mapping: &FxHashMap<String, TransitionKey>,
     alphabet_anything_value: TransitionKey,
     token_str: &str,
 ) -> Vec<TransitionKey> {
@@ -105,12 +105,12 @@ pub fn get_token_transition_keys(
 }
 
 pub fn get_vocabulary_transition_keys(
-    alphabet_symbol_mapping: &HashMap<String, TransitionKey>,
+    alphabet_symbol_mapping: &FxHashMap<String, TransitionKey>,
     alphabet_anything_value: TransitionKey,
     vocabulary: &Vocabulary,
-    frozen_tokens: &HashSet<String>,
-) -> HashMap<Token, Vec<TransitionKey>> {
-    let mut vocab_transition_keys = HashMap::new();
+    frozen_tokens: &FxHashSet<String>,
+) -> FxHashMap<Token, Vec<TransitionKey>> {
+    let mut vocab_transition_keys = FxHashMap::default();
 
     for item in vocabulary.iter() {
         let token_str = item.0.clone();

--- a/src/vocabulary/mod.rs
+++ b/src/vocabulary/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 
 use tokenizers::normalizers::Sequence;
 use tokenizers::{FromPretrainedParameters, NormalizerWrapper, Tokenizer};
@@ -29,7 +29,7 @@ mod processor;
 pub struct Vocabulary {
     // TODO: Option is temp for back compatibility
     eos_token_id: Option<TokenId>,
-    tokens: HashMap<Token, Vec<TokenId>>,
+    tokens: FxHashMap<Token, Vec<TokenId>>,
 }
 
 impl Vocabulary {
@@ -37,7 +37,7 @@ impl Vocabulary {
     pub fn new(eos_token_id: Option<TokenId>) -> Self {
         Self {
             eos_token_id,
-            tokens: HashMap::new(),
+            tokens: FxHashMap::default(),
         }
     }
 
@@ -174,9 +174,9 @@ impl Vocabulary {
 }
 
 impl std::ops::Deref for Vocabulary {
-    type Target = HashMap<Token, Vec<TokenId>>;
+    type Target = FxHashMap<Token, Vec<TokenId>>;
 
-    fn deref(&self) -> &HashMap<Token, Vec<TokenId>> {
+    fn deref(&self) -> &FxHashMap<Token, Vec<TokenId>> {
         &self.tokens
     }
 }
@@ -194,8 +194,8 @@ impl std::fmt::Display for Vocabulary {
     }
 }
 
-impl From<HashMap<Token, Vec<TokenId>>> for Vocabulary {
-    fn from(tokens: HashMap<Token, Vec<TokenId>>) -> Vocabulary {
+impl From<FxHashMap<Token, Vec<TokenId>>> for Vocabulary {
+    fn from(tokens: FxHashMap<Token, Vec<TokenId>>) -> Vocabulary {
         Vocabulary {
             eos_token_id: None,
             tokens,
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn new_empty_vocabulary_from_hashmap() {
-        let map = HashMap::new();
+        let map = FxHashMap::default();
         let vocabulary = Vocabulary::from(map);
         assert!(vocabulary.eos_token_id.is_none());
         assert!(vocabulary.tokens.is_empty());


### PR DESCRIPTION
Rust's default HashMap Hash functions ( from SipHash ) are very slow since they do things like collision avoidance, and try to ensure uniform key distribution. These features seems un-needed, and for a library such as outlines-core focused on performance, it seems to be detrimental. Replacing the default rust HashMap with the hash map from `rustc_hash` makes this way faster, since it massively reduces hashing overhead. 

Benchmarks Before & After:
```
| Change   | Before [617a2c8e] <0.1.19>   | After [175ea196] <main~1>   | Ratio   | Benchmark (Parameter)                                                                                              |
|----------|------------------------------|-----------------------------|---------|--------------------------------------------------------------------------------------------------------------------|
| -        | 2.57±0.5s                    | 1.48±0.1s                   | 0.58    | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('complex_schema')                                    |
| -        | 1.35±0.5s                    | 786±70ms                    | 0.58    | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_fsm('simple_schema')                                     |
|          | 16.3±2μs                     | 15.6±0.3μs                  | 0.96    | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('complex_schema')                                  |
|          | 6.10±2μs                     | 6.47±0.2μs                  | 1.06    | bench_json_schema.JsonSchemaBenchmark.time_json_schema_to_regex('simple_schema')                                   |
|          | 405M                         | 407M                        | 1.00    | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('complex_span_constrained_relation_extraction') |
|          | 401M                         | 403M                        | 1.01    | bench_regex_guide.MemoryRegexGuideBenchmark.peakmem_regex_to_guide('simple_phone')                                 |
| -        | 720±100ms                    | 351±10ms                    | 0.49    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_phone')                                         |
| -        | 3.30±0.09s                   | 1.96±0.2s                   | 0.60    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('complex_span_constrained_relation_extraction')          |
| -        | 528±90ms                     | 279±20ms                    | 0.53    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('date')                                                  |
| -        | 387±50ms                     | 249±10ms                    | 0.64    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('email')                                                 |
|          | 381±60ms                     | 278±40ms                    | ~0.73   | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ip')                                                    |
| -        | 347±70ms                     | 216±6ms                     | 0.62    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('simple_phone')                                          |
| -        | 306±40ms                     | 207±9ms                     | 0.68    | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('ssn')                                                   |
|          | 292±60ms                     | 253±30ms                    | ~0.87   | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('time')                                                  |
|          | 479±80ms                     | 303±10ms                    | ~0.63   | bench_regex_guide.RegexGuideBenchmark.time_regex_to_guide('url')                                                   |
```

`pyo3` already has built in conversion traits for `FxHashMap`s from `rustc_hash`, so python bindings / python usage does not change at all. All pre-commit hooks and tests pass. 
This adds the dependency of `rustc_hash`, and the `hashbrown` feature of `pyo3` for the conversion traits.