### PR TITLE
Allow uncommitted VCS changes to be packaged in CI

### DIFF
--- a/.github/workflows/release_rust.yaml
+++ b/.github/workflows/release_rust.yaml
@@ -43,4 +43,5 @@ jobs:
     - name: Publish to crates.io
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      run: cargo publish
+      # We need --allow-dirty since we dynamically change the version in Cargo.toml
+      run: cargo publish --allow-dirty


### PR DESCRIPTION
We dynamically change the version in Cargo.toml based on the current tag, so the Cargo.toml file is not staged when we use `cargo publish`. Since this will be the only file that is not tracked by `git` it is safe to use the `--allow-dirty` option.