### PR TITLE
Do not bump Cargo version before releasing to PyPi

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -21,10 +21,6 @@ jobs:
         with:
           python-version: '3.10'
 
-      - name: Bump Cargo version
-        run: |
-          python ./.github/scripts/cargo_version_bumper.py --target Cargo.toml "${{ github.ref_name }}"
-
       - name: Set up QEMU
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
When we bump the version of Cargo.toml in CI we introduced an uncommited change, and the state of the branch is then used to determine the PyPi release version number.