### PR TITLE
Allow threads on `Index` creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ test = [
     "datasets",
     "pillow",
     "asv",
+    "psutil",
     "setuptools-rust",
 ]
 

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -80,14 +80,17 @@ pub struct PyIndex(Index);
 impl PyIndex {
     #[new]
     fn new(
+        py: Python<'_>,
         fsm_info: &PyFSMInfo,
         vocabulary: &PyVocabulary,
         eos_token_id: u32,
         frozen_tokens: FxHashSet<String>,
     ) -> PyResult<Self> {
-        Index::new(&fsm_info.into(), &vocabulary.0, eos_token_id, frozen_tokens)
-            .map(PyIndex)
-            .map_err(Into::into)
+        py.allow_threads(|| {
+            Index::new(&fsm_info.into(), &vocabulary.0, eos_token_id, frozen_tokens)
+                .map(PyIndex)
+                .map_err(Into::into)
+        })
     }
 
     fn __reduce__(&self) -> PyResult<(PyObject, (Vec<u8>,))> {


### PR DESCRIPTION
Closes #113 

GIL prevents several threads from executing Python bytecode in parallel, so if multiple threads are created, only one thread can execute Python bytecode at any given time.

### Release the GIL
To temporarily release the GIL for the cpu-heavy index creation step pyo3's `allow_threads` seems to be enough to allow other Python threads to run and to get roughly x2+ improvement in multithreaded case, where number of threads is equal to the number of physical cores.

Compare current situation on main branch without `allow_threads`, tested on my local machine with 6 threads (6 physical cores):
![on_main](https://github.com/user-attachments/assets/99d3704e-a865-4569-9d58-8bddf9acee6d)

To these benchmarks with `allow_threads` on index creation and different number of threads:
![diff num cores](https://github.com/user-attachments/assets/15d8afe3-2aa2-44d8-9729-067b78b6e200)

Of course, amount of threads will still affect the results due to GIL's overall overhead, here as expected: less threads, better results.

Also, separately confirmed equal thread usage with `top`:
![parallel2](https://github.com/user-attachments/assets/2b1bd881-4c5a-412c-8c92-6a2096f10d49)

### GIL's switch interval affects too

CPU-bound tasks are especially limited by the GIL since they require continuous execution of Python bytecode and default GIL's switch interval is 5ms. To show this effect I added a benchmark with increased interval to 5 secs (the same 6 threads):
![custom switch interval](https://github.com/user-attachments/assets/70294b3b-9573-472d-ad46-25062b63861a)

These results are much closer to the one-threaded case, than the ones with default GIL's switch interval.