### PR TITLE
No release workflows on PRs

### DIFF
--- a/.github/workflows/release_pypi.yaml
+++ b/.github/workflows/release_pypi.yaml
@@ -4,8 +4,6 @@ on:
   release:
     types:
       - created
-  pull_request:
-    branches: [main]
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Was accidently forgotten to be removed in: https://github.com/dottxt-ai/outlines-core/pull/123