### PR TITLE
Add Minimum Supported Rust Version (MSRV) to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Or install in a rust project with cargo:
 cargo add outlines-core
 ```
 
+**Note:** The Minimum Supported Rust Version (MSRV) for this project is 1.78.0.
+
 # How to contribute?
 
 ## Setup


### PR DESCRIPTION
I believe this is useful information that could be inferred by tools like [`cargo-msrv`](https://github.com/foresterre/cargo-msrv) and potentially [added directly to `Cargo.toml`](https://doc.rust-lang.org/cargo/reference/rust-version.html), WDYT?