### PR TITLE
Re-export public APIs in __init__.py

### DIFF
--- a/python/outlines_core/__init__.py
+++ b/python/outlines_core/__init__.py
@@ -1,7 +1,10 @@
 """This package provides core functionality for structured generation, formerly implemented in Outlines."""
+
 from importlib.metadata import PackageNotFoundError, version
 
-from .outlines_core_rs import Guide, Index, Vocabulary
+from .outlines_core_rs import Guide as Guide
+from .outlines_core_rs import Index as Index
+from .outlines_core_rs import Vocabulary as Vocabulary
 
 try:
     __version__ = version("outlines_core")


### PR DESCRIPTION
`from .x import y as y` is a widely recognized way to re-export public APIs. Linters and IDEs are happier with this notation.