### PR TITLE
Add --allow-dirty flag to cargo publish dry-run commands

### DIFF
--- a/.github/workflows/dry_run_publish.yml
+++ b/.github/workflows/dry_run_publish.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Dry-run publish to crates.io
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./.github/actions/bump_version
 
       - name: Dry-run publish to crates.io
-        run: cargo publish --dry-run
+        run: cargo publish --dry-run --allow-dirty
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
When the Cargo publish dry run step was added, the `--allow-dirty` flag was not included. We need to include it as the version bump done in an action before is not committed, so an error will be raised otherwise.

This flag is already used in the step for the real publication to crates.io:
```
      - name: Publish to crates.io
        env:
          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
        # We need --allow-dirty since we dynamically change the version in Cargo.toml
        run: cargo publish --allow-dirty
```