### PR TITLE
Fix the error causing the wheels installation to fail

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -200,6 +200,7 @@ jobs:
         if: matrix.platform.target == 'aarch64'
         run: |
           pip install outlines_core --no-index --find-links dist --force-reinstall
+          cd outlines_core
           python -c "import outlines_core"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update 2025/04/03

There is an error in the workflow to build the wheels in the `Install build wheels` [step](https://github.com/dottxt-ai/outlines-core/actions/runs/14191129825/job/39755856742)

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import outlines_core
  File "/home/runner/work/outlines-core/outlines-core/outlines_core/__init__.py", line 1, in <module>
    from .outlines_core import Guide, Index, Vocabulary
ModuleNotFoundError: No module named 'outlines_core.outlines_core'
```

This error comes from the fact that there's an import conflict between the local directory `outlines_core` (that has an `__init__.py` so is treated as a module) and the `outlines_core` package that has just been installed. This issue does not happen when using `materin develop` because it adds the `.so` file in the `outlines_core` local directory such that the relative import at the top of the `__init__.py` file (`from .outlines_core import Guide, Index, Vocabulary`) correctly points to it.

I propose to solve it by simply moving to a different location before running `python -c "import outlines_core"` in the workflow to check that the package installed is alright. I think this would work because when installing `outlines_core` from outside of this repo, the conflict does not exist while, when being in this repo in dev mode, we would use `maturin develop` that also solves the problem.
