### PR TITLE
Fix missing command in build_wheels workflow

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -69,6 +69,7 @@ jobs:
         if: matrix.platform.target == 'x86_64'
         run: |
           pip install outlines_core --no-index --find-links dist --force-reinstall
+          cd outlines_core
           python -c "import outlines_core"
 
       - uses: actions/upload-artifact@v4
@@ -132,6 +133,7 @@ jobs:
       - name: Install built wheel
         run: |
           pip install outlines_core --no-index --find-links dist --force-reinstall
+          cd outlines_core
           python -c "import outlines_core"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
PR #202 fixed an issue related to the build_wheels workflow but mistakenly applied it only to the macos job instead of also applying to windows and linux.