### PR TITLE
Fix: Error when creating index from schema with Uri

### DIFF
--- a/src/json_schema/mod.rs
+++ b/src/json_schema/mod.rs
@@ -1048,16 +1048,16 @@ mod tests {
                 r#"{"title": "Foo", "type": "string", "format": "uri"}"#,
                 URI,
                 vec![
-                    "http://example.com",
-                    "https://example.com/path?query=param#fragment",
-                    "ftp://ftp.example.com/resource",
-                    "urn:isbn:0451450523",
+                    r#""http://example.com""#,
+                    r#""https://example.com/path?query=param#fragment""#,
+                    r#""ftp://ftp.example.com/resource""#,
+                    r#""urn:isbn:0451450523""#,
                 ],
                 vec![
-                    "http:/example.com", // missing slash
-                    "htp://example.com", // invalid scheme
-                    "http://",           // missing host
-                    "example.com",       // missing scheme
+                    r#""http:/example.com""#, // missing slash
+                    r#""htp://example.com""#, // invalid scheme
+                    r#""http://""#,           // missing host
+                    r#""example.com""#,       // missing scheme
                 ]
             ),
             (
@@ -1065,23 +1065,23 @@ mod tests {
                 EMAIL,
                 vec![
                     // Valid emails
-                    "user@example.com",               // valid
-                    "user.name+tag+sorting@example.com", // valid
-                    "user_name@example.co.uk",         // valid
-                    "user-name@sub.example.com",       // valid
+                    r#""user@example.com""#,               // valid
+                    r#""user.name+tag+sorting@example.com""#, // valid
+                    r#""user_name@example.co.uk""#,         // valid
+                    r#""user-name@sub.example.com""#,       // valid
                 ],
                 vec![
                     // Invalid emails
-                    "plainaddress",                   // missing '@' and domain
-                    "@missingusername.com",           // missing username
-                    "username@.com",                  // leading dot in domain
-                    "username@com",                   // TLD must have at least 2 characters
-                    "username@example,com",           // invalid character in domain
-                    "username@.example.com",          // leading dot in domain
-                    "username@-example.com",          // domain cannot start with a hyphen
-                    "username@example-.com",          // domain cannot end with a hyphen
-                    "username@example..com",          // double dot in domain name
-                    "username@.example..com",         // multiple errors in domain
+                    r#""plainaddress""#,                   // missing '@' and domain
+                    r#""@missingusername.com""#,           // missing username
+                    r#""username@.com""#,                  // leading dot in domain
+                    r#""username@com""#,                   // TLD must have at least 2 characters
+                    r#""username@example,com""#,           // invalid character in domain
+                    r#""username@.example.com""#,          // leading dot in domain
+                    r#""username@-example.com""#,          // domain cannot start with a hyphen
+                    r#""username@example-.com""#,          // domain cannot end with a hyphen
+                    r#""username@example..com""#,          // double dot in domain name
+                    r#""username@.example..com""#,         // multiple errors in domain
                 ]
             ),
 

--- a/src/json_schema/mod.rs
+++ b/src/json_schema/mod.rs
@@ -1084,6 +1084,32 @@ mod tests {
                     r#""username@.example..com""#,         // multiple errors in domain
                 ]
             ),
+            // Nested URI and email
+            (
+                r#"{
+                    "title": "Test Schema",
+                    "type": "object",
+                    "properties": {
+                        "test_str": {"title": "Test string", "type": "string"},
+                        "test_uri": {"title": "Test URI", "type": "string", "format": "uri"},
+                        "test_email": {"title": "Test email", "type": "string", "format": "email"}
+                    },
+                    "required": ["test_str", "test_uri", "test_email"]
+                }"#,
+                format!(
+                    r#"\{{{0}"test_str"{0}:{0}{STRING}{0},{0}"test_uri"{0}:{0}{URI}{0},{0}"test_email"{0}:{0}{EMAIL}{0}\}}"#,
+                    WHITESPACE
+                ).as_str(),
+                vec![
+                    r#"{ "test_str": "cat", "test_uri": "http://example.com", "test_email": "user@example.com" }"#,
+                ],
+                vec![
+                    // Invalid URI
+                    r#"{ "test_str": "cat", "test_uri": "http:/example.com", "test_email": "user@example.com" }"#,
+                    // Invalid email
+                    r#"{ "test_str": "cat", "test_uri": "http://example.com", "test_email": "username@.com" }"#,
+                ]
+            ),
 
             // ==========================================================
             //                      Multiple types

--- a/src/json_schema/types.rs
+++ b/src/json_schema/types.rs
@@ -45,9 +45,9 @@ pub static TIME: &str = r#""(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9
 // https://datatracker.ietf.org/doc/html/rfc9562 and https://stackoverflow.com/questions/136505/searching-for-uuids-in-text-with-regex
 pub static UUID: &str = r#""[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}""#;
 // https://datatracker.ietf.org/doc/html/rfc3986#appendix-B
-pub static URI: &str = r#"^(https?|ftp):\/\/([^\s:@]+(:[^\s:@]*)?@)?([a-zA-Z\d.-]+\.[a-zA-Z]{2,}|localhost)(:\d+)?(\/[^\s?#]*)?(\?[^\s#]*)?(#[^\s]*)?$|^urn:[a-zA-Z\d][a-zA-Z\d\-]{0,31}:[^\s]+$"#;
+pub static URI: &str = r#""(?:(https?|ftp):\/\/([^\s:@]+(:[^\s:@]*)?@)?([a-zA-Z\d.-]+\.[a-zA-Z]{2,}|localhost)(:\d+)?(\/[^\s?#]*)?(\?[^\s#]*)?(#[^\s]*)?|urn:[a-zA-Z\d][a-zA-Z\d\-]{0,31}:[^\s]+)""#;
 // https://www.rfc-editor.org/rfc/rfc5322 and https://stackoverflow.com/questions/13992403/regex-validation-of-email-addresses-according-to-rfc5321-rfc5322
-pub static EMAIL: &str = r#"^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$"#;
+pub static EMAIL: &str = r#""(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""#;
 
 /// Supported format type of the `JsonType::String`.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Fixes #182

The regex for Uris and Emails had problems:
- Included `^` and `$`, but it doesn't make sense to match the start and end of line when the Uris and Emails can be in the middle of a JSON file.
- Was missing start and end quotes. They are stored as strings within JSON.