### PR TITLE
Use pypa to publish to pypi instead of maturin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,13 +45,17 @@ jobs:
       - name: Dry-run publish to crates.io
         run: cargo publish --dry-run --allow-dirty
 
-      - name: Publish to PyPI
-        uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_SECRET}}
+      - name: Print directory information
+        run: |
+          pwd
+          ls -la
+          ls -la dist
+
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
-          command: upload
-          args: --non-interactive --skip-existing dist/*
+          user: __token__
+          password: ${{ secrets.PYPI_SECRET }}
 
       - name: Publish to crates.io
         env:

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -92,7 +92,7 @@ impl PyGuide {
     /// `data_ptr` should be the data ptr to a `torch.tensor`, or `np.ndarray`, `mx.array` or other
     /// contiguous memory array.
     fn write_mask_into(&self, data_ptr: usize, numel: usize, element_size: usize) -> PyResult<()> {
-        let expected_elements = (self.index.0.vocab_size() + 31) / 32;
+        let expected_elements = self.index.0.vocab_size().div_ceil(32);
         if element_size != 4 {
             return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
                 format!(


### PR DESCRIPTION
As we are having issues with the `maturin upload` action, this PR proposes to use the pypa action that is used in Outlines to publish the wheels to pypi. It also adds a debug step that prints out some information on the working directory and that are intended to be removed in the future.