### PR TITLE
Fix issue publish workflow + restore maturin for upload

### DIFF
--- a/.github/actions/bump_version/action.yml
+++ b/.github/actions/bump_version/action.yml
@@ -11,6 +11,7 @@ runs:
       # To fetch all the tags and history
       with:
         fetch-depth: 0
+        clean: false
 
     - name: Bump version in Cargo.toml
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Bump version in Cargo.toml
@@ -51,11 +52,13 @@ jobs:
           ls -la
           ls -la dist
 
-      - name: Publish to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_SECRET}}
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_SECRET }}
+          command: upload
+          args: --non-interactive --skip-existing dist/*
 
       - name: Publish to crates.io
         env:


### PR DESCRIPTION
This PR fixes the origin of the problem we encountered to publish the wheels to pypi: a checkout step was cleaning the content of the repository (that includes the `dist` directory). As the issue was unrelated to maturin, it also restores it for the upload to pypi step.