### PR TITLE
Fix `cargo audit` in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.85.0"
 [dependencies]
 once_cell = "1.20"
 thiserror = "2.0"
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.24", features = ["extension-module"], optional = true }
 regex = "1.10.6"
-serde-pyobject = { version = "0.5.0", optional = true }
+serde-pyobject = { version = "0.6.1", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = {version = "1.0", features = ["derive"]}
 bincode = "2.0.1"


### PR DESCRIPTION
Upgrade packages the minimum amount to pass `cargo audit`. Upgrade `pyo3` from 0.23 to 0.24, which also requires upgrading `serde-pyobject` from 0.5.0 to at least 0.6.1.

`cargo audit` currently gives this output:
```
Crate:     pyo3
Version:   0.23.5
Title:     Risk of buffer overflow in `PyString::from_object`
error: 1 vulnerability found!
warning: 1 allowed warning found
Date:      [20](https://github.com/dottxt-ai/outlines-core/actions/runs/15111854721/job/42472939969?pr=214#step:6:21)25-04-01
ID:        RUSTSEC-2025-0020
URL:       https://rustsec.org/advisories/RUSTSEC-2025-0020
Solution:  Upgrade to >=0.24.1
Dependency tree:
pyo3 0.[23](https://github.com/dottxt-ai/outlines-core/actions/runs/15111854721/job/42472939969?pr=214#step:6:24).5
├── serde-pyobject 0.5.0
│   └── outlines-core 0.0.0
└── outlines-core 0.0.0
```