### PR TITLE
Add pyo3/generate-import-lib to the python-bindings in the Cargo file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-features = false
 
 [features]
 default = ["hugginface-hub"]
-python-bindings = ["pyo3", "serde-pyobject"]
+python-bindings = ["pyo3", "pyo3/generate-import-lib", "serde-pyobject"]
 hugginface-hub = ["hf-hub", "tokenizers/http",  "tokenizers/rustls-tls"]
 
 [lib]


### PR DESCRIPTION
The latest release (0.2.12) failed because of an error in the Windows build, see the GH [action](https://github.com/dottxt-ai/outlines-core/actions/runs/18522748226/job/52786268173)

I suppose this is caused by the upgrade of the `pyo3` version used in the release from 0.23 to 0.24. Following the suggestion in the stack trace of the failed build, this PR proposes to add `pyo3/generate-import-lib` to the `python-bindings` of the features in the `Cargo.toml `