### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,11 +23,11 @@ jobs:
           - runner: ubuntu-22.04
             target: x86_64
             manylinux: auto
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
           - runner: ubuntu-22.04
             target: aarch64
             manylinux: manylinux_2_28
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - run: pip install -U twine
 
@@ -86,11 +86,11 @@ jobs:
           - runner: windows-latest
             target: x86
             alias-target: i686-pc-windows-msvc
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
           - runner: windows-latest
             target: x64
             alias-target: x86_64-pc-windows-msvc
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
 
     steps:
       - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           architecture: ${{ matrix.platform.target }}
 
       - run: pip install -U twine
@@ -150,19 +150,19 @@ jobs:
           - runner: macos-14
             target: x86_64
             macos_version: "14.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
           - runner: macos-14
             target: aarch64
             macos_version: "14.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
           - runner: macos-15
             target: x86_64
             macos_version: "15.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
           - runner: macos-15
             target: aarch64
             macos_version: "15.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
 
     steps:
       - uses: actions/checkout@v3
@@ -170,7 +170,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - run: pip install -U twine
 


### PR DESCRIPTION
I've updated the required dependencies (pyo3 and serde-pyobject) to versions that support Python 3.14.
This caused a compilation error when building, which I've fixed in `src/python_bindings/mod.rs` by adding a type hint.
Furthermore, I've added 3.14 as a build target in the `build_wheels.yml` github workflow.

Running `make test` still failed on 4 tests:
```
FAILED tests/test_kernels.py::test_interface_torch - RuntimeError: torch.compile is not supported on Python 3.14+
FAILED tests/test_kernels.py::test_interface_numpy - ImportError: To use the kernels in `outlines_core.kernels.numpy`, `numba` must be installed. You can install it with `pip install numba`
FAILED tests/test_kernels.py::test_torch_correctness - RuntimeError: torch.compile is not supported on Python 3.14+
FAILED tests/test_kernels.py::test_numpy_correctness - ImportError: To use the kernels in `outlines_core.kernels.numpy`, `numba` must be installed. You can install it with `pip install numba`
```

This is due to numba not supporting 3.14 and torch only partially supporting it.