### PR TITLE
Remove the eos_token from allowed tokens in the Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,6 @@ next_allowed_tokens = guide.advance(allowed_tokens[-1])
 
 # To check if Guide is finished:
 guide.is_finished()
-
-# If it's finished then this assertion holds:
-assert guide.get_tokens() == [vocabulary.get_eos_token_id()]
 ```
 
 ## How to contribute?

--- a/src/index.rs
+++ b/src/index.rs
@@ -226,9 +226,6 @@ impl Index {
 
     /// Returns transition state for a given state and token id or `None` otherwise.
     pub fn next_state(&self, state: &StateId, token_id: &TokenId) -> Option<StateId> {
-        if token_id == &self.eos_token_id {
-            return None;
-        }
         Some(*self.transitions.get(state)?.get(token_id)?)
     }
 
@@ -284,7 +281,7 @@ mod tests {
         assert_eq!(index.next_state(&initial_state, token_id), Some(state));
         assert!(index.is_final_state(&state));
 
-        assert_eq!(index.next_state(&state, &eos_token_id), None);
+        assert_eq!(index.next_state(&state, &eos_token_id), Some(state));
         assert_eq!(index.next_state(&state, token_id), None);
     }
 

--- a/src/json_schema/parsing.rs
+++ b/src/json_schema/parsing.rs
@@ -65,7 +65,7 @@ impl<'a> Parser<'a> {
 
     fn parse_empty_object(&mut self) -> Result<String> {
         // JSON Schema Spec: Empty object means unconstrained, any json type is legal
-        let types = vec![
+        let types = [
             json!({"type": "boolean"}),
             json!({"type": "null"}),
             json!({"type": "number"}),


### PR DESCRIPTION
Addresses #227 

This PR aims at fixing a contradictory behavior in the current implementation of the `Index` class: the `eos_token` is listed in the output of the function `allowed_tokens`, but it cannot be consumed in the `next_state` function. As a result, in the `Guide`, the `eos_token` is returned by the `get_tokens` function but causes an error if used when calling the `advance` function.

The solution proposed here is not to include the `eos_token` in the allowed tokens to harmonize on the behavior of the `advance` function of the `Guide` class.

After it we still have an odd situation in which the `eos_token` is part of the `transitions`, but without being an allowed token. However, it does fix the main source of errors for users as the functions they are likely to use are now consistent.

For the complete fix of the problem, I was proposing in the issue above to allow consuming the `eos_token` but I'm not sure it's the best anymore as it would mean modifying the behavior of the guide and one could argue it conceptually does not make sense to consume the `eos_token` token and remain in the same state. If we take the other way in the continuation of what's proposed here, we would need to explore fully removing the `eos_token` from the transitions.