### PR TITLE
Allow the guide to consume the eos_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,6 @@ next_allowed_tokens = guide.advance(allowed_tokens[-1])
 # To check if Guide is finished:
 guide.is_finished()
 
-# If it's finished then this assertion holds:
-assert guide.get_tokens() == [vocabulary.get_eos_token_id()]
-```
-
 ## How to contribute?
 
 ### Setup

--- a/src/index.rs
+++ b/src/index.rs
@@ -226,9 +226,6 @@ impl Index {
 
     /// Returns transition state for a given state and token id or `None` otherwise.
     pub fn next_state(&self, state: &StateId, token_id: &TokenId) -> Option<StateId> {
-        if token_id == &self.eos_token_id {
-            return None;
-        }
         Some(*self.transitions.get(state)?.get(token_id)?)
     }
 
@@ -284,7 +281,7 @@ mod tests {
         assert_eq!(index.next_state(&initial_state, token_id), Some(state));
         assert!(index.is_final_state(&state));
 
-        assert_eq!(index.next_state(&state, &eos_token_id), None);
+        assert_eq!(index.next_state(&state, &eos_token_id), Some(state));
         assert_eq!(index.next_state(&state, token_id), None);
     }
 

--- a/src/json_schema/parsing.rs
+++ b/src/json_schema/parsing.rs
@@ -65,7 +65,7 @@ impl<'a> Parser<'a> {
 
     fn parse_empty_object(&mut self) -> Result<String> {
         // JSON Schema Spec: Empty object means unconstrained, any json type is legal
-        let types = vec![
+        let types = [
             json!({"type": "boolean"}),
             json!({"type": "null"}),
             json!({"type": "number"}),

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -210,7 +210,7 @@ def test_rollback_interface(index):
         ([1], True),  # single allowed token: accept
         ([2], True),  # different allowed token: accept
         ([1, 1], False),  # too long for r"[1-9]": reject
-        ([2, 3], False),  # extra token: reject
+        ([2, 3], True),  # extra token: accept at the final state
     ],
 )
 def test_accepts_tokens_correctness(index, seq, expected):


### PR DESCRIPTION
Addresses https://github.com/dottxt-ai/outlines-core/issues/227

This PR aims at fixing a contradictory behavior in the current implementation of the Index class: the `eos_token` is listed in the output of the function `allowed_tokens`, but it cannot be consumed in the `next_state` function. As a result, in the `Guide`, the `eos_token` is returned by the `get_tokens` function but causes an error if used when calling the advance function.

The solution proposed here is to allow the `Guide` to consume the eos_token such that calling the `next_state` function with the `eos_token` as an argument leads to the current state.

Downside: if some users expect the `eos_token` to be rejected, by the `Guide.accepts_tokens` function for instance, it could lead to unexpected behavior for them. An exemple would be this implementation in [vllm](https://github.com/vllm-project/vllm/blob/main/vllm/v1/structured_output/backend_outlines.py):

```python
    def accept_tokens(self, request_id: str, tokens: list[int]) -> bool:
        """Accepts a list of tokens and advances the FSM.

        Returns True if the FSM was advanced successfully.
        Returns False if the FSM failed to advance.
        """
        if self.guide.accepts_tokens(tokens):
            # Advance cannot fail because we checked Guide.accepts_tokens()
            for t in tokens:
                self.guide.advance(t)
                self.num_processed_tokens += 1
            return True
        return False
```