### PR TITLE
Support Python 3.14 (without changes to github actions)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.85.0"
 [dependencies]
 once_cell = "1.20"
 thiserror = "2.0"
-pyo3 = { version = "0.24", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.27", features = ["extension-module"], optional = true }
 regex = "1.10.6"
-serde-pyobject = { version = "0.6.1", optional = true }
+serde-pyobject = { version = "0.8.0", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = {version = "1.0", features = ["derive"]}
 bincode = "2.0.1"

--- a/src/python_bindings/mod.rs
+++ b/src/python_bindings/mod.rs
@@ -506,7 +506,7 @@ fn register_child_module(parent_module: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(build_regex_from_schema_py, &m)?)?;
 
     let sys = PyModule::import(m.py(), "sys")?;
-    let sys_modules_bind = sys.as_ref().getattr("modules")?;
+    let sys_modules_bind = (sys.as_ref() as &Bound<PyAny>).getattr("modules")?;
     let sys_modules = sys_modules_bind.downcast::<PyDict>()?;
     sys_modules.set_item("outlines_core.json_schema", &m)?;
 


### PR DESCRIPTION
As suggested by @ngoldbaum in https://github.com/dottxt-ai/outlines-core/pull/235, I'm recreating a PR for the Python 3.14 fix without the changes in the `.github/workflows/build_wheels.yml` file.
This because while outlines-core works on 3.14 with the updated dependencies, not all tests pass yet due to dependencies (numba, torch) that are not yet compatible. I've attached the description of my original PR for reference:

---

I've updated the required dependencies (pyo3 and serde-pyobject) to versions that support Python 3.14.
This caused a compilation error when building, which I've fixed in `src/python_bindings/mod.rs` by adding a type hint.
~Furthermore, I've added 3.14 as a build target in the `build_wheels.yml` github workflow.~

Running `make test` still failed on 4 tests:
```
FAILED tests/test_kernels.py::test_interface_torch - RuntimeError: torch.compile is not supported on Python 3.14+
FAILED tests/test_kernels.py::test_interface_numpy - ImportError: To use the kernels in `outlines_core.kernels.numpy`, `numba` must be installed. You can install it with `pip install numba`
FAILED tests/test_kernels.py::test_torch_correctness - RuntimeError: torch.compile is not supported on Python 3.14+
FAILED tests/test_kernels.py::test_numpy_correctness - ImportError: To use the kernels in `outlines_core.kernels.numpy`, `numba` must be installed. You can install it with `pip install numba`
```

This is due to numba not supporting 3.14 and torch only partially supporting it.