### PR TITLE
Upgrade `tokenizers` to v0.22.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-features = false
 optional = true
 
 [dependencies.tokenizers]
-version = "=0.21.1"
+version = "0.22.2"
 features = ["onig"]
 default-features = false
 

--- a/src/vocabulary/mod.rs
+++ b/src/vocabulary/mod.rs
@@ -183,7 +183,7 @@ impl Vocabulary {
                 NormalizerWrapper::Sequence(normalization_sequence) => {
                     let new_sequence = Sequence::new(
                         normalization_sequence
-                            .get_normalizers()
+                            .as_ref()
                             .iter()
                             .filter_map(|normalizer| match normalizer {
                                 NormalizerWrapper::Prepend(_) => None,
@@ -497,7 +497,7 @@ mod tests {
             if let Some(n) = normalized_t.get_normalizer() {
                 match n {
                     NormalizerWrapper::Sequence(seq) => {
-                        for n in seq.get_normalizers() {
+                        for n in seq.as_ref() {
                             if let NormalizerWrapper::Prepend(_) = n {
                                 unreachable!()
                             }


### PR DESCRIPTION
The main fix I want is https://github.com/huggingface/tokenizers/pull/1771. Without it, building `outlines-core` on a newer C compiler results in function signature mismatch errors.