### PR TITLE
Add multithreaded tests and enable cp314t wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,11 +23,11 @@ jobs:
           - runner: ubuntu-22.04
             target: x86_64
             manylinux: auto
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
           - runner: ubuntu-22.04
             target: aarch64
             manylinux: manylinux_2_28
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
 
     steps:
       - uses: actions/checkout@v3
@@ -86,11 +86,11 @@ jobs:
           - runner: windows-latest
             target: x86
             alias-target: i686-pc-windows-msvc
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
           - runner: windows-latest
             target: x64
             alias-target: x86_64-pc-windows-msvc
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
 
     steps:
       - uses: actions/checkout@v3
@@ -150,19 +150,19 @@ jobs:
           - runner: macos-14
             target: x86_64
             macos_version: "14.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
           - runner: macos-14
             target: aarch64
             macos_version: "14.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
           - runner: macos-15
             target: x86_64
             macos_version: "15.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
           - runner: macos-15
             target: aarch64
             macos_version: "15.0"
-            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14"
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,11 @@ jobs:
         .venv/bin/python -m pytest --cov=outlines_core -vv
       env:
         COVERAGE_FILE: .coverage.${{ steps.matrix-id.outputs.id }}
+    - name: Run tests under pytest-run-parallel
+      if: ${{ matrix.python-version[0] }} == "3.14t"
+      run: |
+        .venv/bin/python -m pip install pytest-run-parallel
+        .venv/bin/python -m pytest -vv --parallel-threads=auto
     - name: Upload coverage data
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
       if: ${{ matrix.python-version[0] == '3.14t' }}
       run: |
         .venv/bin/python -m pip install pytest-run-parallel
-        .venv/bin/python -m pytest -vv --parallel-threads=auto
+        .venv/bin/python -m pytest -vv --parallel-threads=auto --skip-thread-unsafe=true
     - name: Upload coverage data
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,8 +59,8 @@ jobs:
         .venv/bin/python -m pytest --cov=outlines_core -vv
       env:
         COVERAGE_FILE: .coverage.${{ steps.matrix-id.outputs.id }}
-    - name: Run tests under pytest-run-parallel
-      if: ${{ matrix.python-version[0] }} == "3.14t"
+    - name: Run tests under pytest-run-parallel (${{ matrix.python-version[0] }} only)
+      if: ${{ matrix.python-version[0] == '3.14t' }}
       run: |
         .venv/bin/python -m pip install pytest-run-parallel
         .venv/bin/python -m pytest -vv --parallel-threads=auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,9 @@ filterwarnings = [
 addopts = [
     "--import-mode=importlib"
 ]
+markers = [
+    "thread_unsafe: Mark a test as thread-unsafe under pytest-run-parallel",
+]
 
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ filterwarnings = [
 addopts = [
     "--import-mode=importlib"
 ]
+# provided by pytest-run-parallel but added here because
+# pytest-run-parallel isn't a required test dependency
 markers = [
     "thread_unsafe: Mark a test as thread-unsafe under pytest-run-parallel",
 ]

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -110,6 +110,7 @@ def test_pickling(index):
     assert sorted(deserialized.get_tokens()) == sorted(guide.get_tokens())
 
 
+@pytest.mark.thread_unsafe(reason="resource-intensive in parallel")
 @pytest.mark.parametrize(
     "model, revision",
     [

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -13,6 +13,7 @@ def vocabulary():
     return Vocabulary(eos_token_id, tokens)
 
 
+@pytest.mark.thread_unsafe(reason="mutably borrows a shared Vocabulary")
 def test_basic_vocabulary_interface(vocabulary):
     assert vocabulary.get_eos_token_id() == 3
     assert vocabulary.get("1") == vocabulary.get(b"1") == [1]
@@ -77,6 +78,7 @@ def test_get_bad_type(vocabulary):
         vocabulary.get(1)
 
 
+@pytest.mark.thread_unsafe(reason="mutably borrows a shared Vocabulary")
 def test_insert_bad_type(vocabulary):
     with pytest.raises(
         TypeError,
@@ -85,6 +87,7 @@ def test_insert_bad_type(vocabulary):
         vocabulary.insert(1, 6)
 
 
+@pytest.mark.thread_unsafe(reason="mutably borrows a shared Vocabulary")
 def test_insert_eos_token(vocabulary):
     with pytest.raises(
         ValueError, match="EOS token should not be inserted into Vocabulary"


### PR DESCRIPTION
Fixes #248.

This adds a test run under the 3.14t tests using [pytest-run-parallel](https://github.com/quansight-labs/pytest-run-parallel), a pytest plugin that enables multithreaded stress testing using a project's existing test suite. Each test is run many times simultaneously in a thread pool, exposing issues due to shared or global state.

Since pytest fixtures are shared between tests, threads also share fixtures (see https://github.com/pytest-dev/pytest/issues/13768 if you're curious about ongoing work upstream to make fixtures thread-local), so the existing test suite can be used to generate multithreaded test cases.

If you have any suggestions for an explicitly multithreaded test using the `threading` module inside a pytest test, I'm happy to implement that as well.

Some tests are marked as thread-unsafe because they generate errors like the ones [seen in this test run](https://github.com/ngoldbaum/outlines-core/actions/runs/21255374714/job/61168286737#step:7:107):

```
>       vocabulary.insert("b", 4)
E       RuntimeError: Already borrowed

tests/test_vocabulary.py:21: RuntimeError
```

These are coming from PyO3's runtime borrow checker for mutable python classes.

If you do want to support shared reading and mutation, you would need to mark the PyVocabulary and PyGuide classes as frozen and use some form of thread-safe interior mutability to update the internal state (e.g. with atomics or locks).

One test is marked thread-unsafe because it was very slow on CI.

Finally, I enabled 3.14t wheel builds. I temporarily enabled wheel builds on CI and created a pull request on my fork - all the wheel builds finished successfully: https://github.com/ngoldbaum/outlines-core/actions/runs/21257629495