### PR TITLE
Add s390x wheel build and QEMU smoke tests to CI

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -35,6 +35,11 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             manylinux: manylinux_2_39
             interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
+          - runner: ubuntu-22.04
+            arch: s390x
+            target: s390x-unknown-linux-gnu
+            manylinux: manylinux_2_28
+            interpreter: "3.9 3.10 3.11 3.12 3.13 3.14 3.14t"
 
     steps:
       - uses: actions/checkout@v3
@@ -49,7 +54,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt update
-          sudo apt install pkg-config gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu g++-aarch64-linux-gnu g++-riscv64-linux-gnu -qy
+          sudo apt install pkg-config gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu gcc-s390x-linux-gnu g++-aarch64-linux-gnu g++-riscv64-linux-gnu g++-s390x-linux-gnu -qy
 
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -66,6 +66,10 @@ jobs:
         if: ${{ inputs.auto_bump }}
         uses: ./.github/actions/bump_version
 
+      - name: Set up QEMU
+        if: ${{ !contains(matrix.platform.target, 'x86_64') }}
+        uses: docker/setup-qemu-action@v3
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -83,6 +87,17 @@ jobs:
           pip install outlines_core --no-index --find-links dist --force-reinstall
           cd outlines_core
           python -c "import outlines_core"
+
+      - name: Smoke-test built wheel under QEMU
+        if: contains(matrix.platform.target, 'aarch64') || contains(matrix.platform.target, 's390x')
+        run: |
+          docker run --rm --platform linux/${{ matrix.platform.arch == 'aarch64' && 'arm64' || matrix.platform.arch }} \
+            -v "$PWD:/io" -w /io \
+            python:3.12-slim bash -c "
+              pip install --quiet pytest &&
+              pip install --quiet outlines_core --no-index --find-links dist --force-reinstall &&
+              pytest tests/test_imports.py tests/test_vocabulary.py -v --override-ini='filterwarnings='
+            "
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR adds support for building `s390x` wheels in the CI. It also adds QEMU-based smoke tests to verify the built wheels install and import correctly.

The workflow has been tested on my fork, see the actions run [here](https://github.com/RobinPicard/outlines-core/actions/runs/24714810061)